### PR TITLE
Use “style=index” for glossaries.

### DIFF
--- a/LDM-702.tex
+++ b/LDM-702.tex
@@ -4,7 +4,7 @@
 
 % Package imports go here.
 
-\usepackage[nonumberlist,nogroupskip,toc,numberedsection=autolabel]{glossaries}
+\usepackage[nonumberlist,nogroupskip,toc,numberedsection=autolabel,style=index]{glossaries}
 \usepackage{environ}
 \usepackage{enumitem}
 


### PR DESCRIPTION
Without this, the LaTeX fails to build. Not clear why — something missing in
the default style?