### PR TITLE
Fix handle in lander command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - "docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make'"
 after_success:
   # Deploy website. See https://github.com/lsst-sqre/lander for CLI options
-  - 'lander --upload --ltd-product ldm-672 --pdf LDM-672.pdf --env travis --handle LDM-672 --lsstdoc LDM-672.tex'
+  - 'lander --upload --ltd-product ldm-702 --pdf LDM-702.pdf --env travis --handle LDM-702 --lsstdoc LDM-702.tex'
 env:
   global:
     # LSST the Docs credentials


### PR DESCRIPTION
Fixes a typo in the doc handle in the upload command (`.travis.yml`) that prevented LSST the Docs document uploads.